### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,8 +17,8 @@ activate	KEYWORD2
 deactivate	KEYWORD2
 remove	KEYWORD2
 insert	KEYWORD2
-delay   KEYWORD2
-delay_microseconds KEYWORD2
+delay	KEYWORD2
+delay_microseconds	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -29,4 +29,4 @@ delay_microseconds KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-MAX_TASKS LITERAL1
+MAX_TASKS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords